### PR TITLE
Loosen `peerDependencies` "react" & "react-dom" versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,8 +108,8 @@
     "webpack-cli": "^3.1.1"
   },
   "peerDependencies": {
-    "react": "^16.10.0",
-    "react-dom": "^16.10.0"
+    "react": ">=16.10.0",
+    "react-dom": ">=16.10.0"
   },
   "jest": {
     "preset": "ts-jest/presets/js-with-ts",


### PR DESCRIPTION
Allow people to use React 17 without forcing npm installs. Leaves compatibility to end user. In own testing, 17 is fine with consent-manager.